### PR TITLE
Minor Markdown fixes for links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 The Live Tail Command Line Interface (CLI) is a standalone application that allows you to start and use a Live Tail session from the command line, similar to `tail -f`
 The output is directed to stdout - so you can pipe the output to commands (grep, awk etc)
 
-This feature is documented [here.] (http://help.sumologic.com/Search/Live_Tail/Live_Tail_CLI)
+This feature is documented [here.](http://help.sumologic.com/Search/Live_Tail/Live_Tail_CLI)
 
 ## Installation
 
-[Platform specific binaries are provided for CLI. ] (https://github.com/SumoLogic/livetail-cli/releases)
+[Platform specific binaries are provided for CLI.](https://github.com/SumoLogic/livetail-cli/releases)
 
 Simply extract the archive and place the binaries to a location where you have read/write access. 
 
 ## Usage
 
-Like [SumoLogic] (https://www.sumologic.com), the Live Tail CLI enables you to tail logs in real time by specifying a filter.
+Like [SumoLogic](https://www.sumologic.com), the Live Tail CLI enables you to tail logs in real time by specifying a filter.
 It uses accessId and accessKeys that are used with the SumoLogic API for authentication. 
 You could either provide the credentials each time using -i and -k command line options, or enter them once when prompted and they would be saved locally in config.json file in the same directory as the CLI. 
 
 The first time you run the CLI, the tool will prompt you to choose your deployment.
-See [Help for the correct endpoint.] (http://help.sumologic.com/Send_Data/Collector_Management_API/Sumo_Logic_Endpoints)
+See [Help for the correct endpoint.](http://help.sumologic.com/Send_Data/Collector_Management_API/Sumo_Logic_Endpoints)
 
 * Command Line Options 
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ You could either provide the credentials each time using -i and -k command line 
 The first time you run the CLI, the tool will prompt you to choose your deployment.
 See [Help for the correct endpoint.](http://help.sumologic.com/Send_Data/Collector_Management_API/Sumo_Logic_Endpoints)
 
-* Command Line Options 
+### Command Line Options
+
 ```
 usage: livetail [-h] [-i ACCESSID] [-k ACCESSKEY] [-v] [-c] [filter]
 
@@ -40,17 +41,15 @@ optional arguments:
 ## Examples
 
 Tail all logs from a given Source Host. 
-```
+
+```sh
 ./livetail “_sourceHost = localhost”
 ```
 
 Tail logs from a sourceCategory, grep for a pattern, write it to a file
-```
+
+```sh
 ./livetail “_sourceCategory = service” | grep -i “rate limit exceeded” > out.txt
 ```
 
-
 Happy Tailing!
-
-                            
-


### PR DESCRIPTION
This fixes a minor issue where links in the README weren't being formatted as links because there was an extra space between the link label and the URL. I also trimmed some excess whitespace and added shell syntax highlighting while I was in there.